### PR TITLE
Small fix to install in non-existant paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ clean:
 mrproper: clean
 	rm -f ${APPNAME}
 install:
-	install ${APPNAME} ${BINDIR}/${APPNAME}
+	install -D ${APPNAME} ${BINDIR}/${APPNAME}
 uninstall:
 	rm -f ${BINDIR}/${APPNAME}
 


### PR DESCRIPTION
When INSTALLDIR is an empty directory (ie. when using stow) install will
create the required directory